### PR TITLE
IE9 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.*.sw?
 .DS_Store
 node_modules/

--- a/src/ie8.js
+++ b/src/ie8.js
@@ -1,13 +1,13 @@
 
   /*! (C) WebReflection Mit Style License */
-  if (document.createEvent) return;
+  // if (document.createEvent) return;
   var
     DUNNOABOUTDOMLOADED = true,
     READYEVENTDISPATCHED = false,
     ONREADYSTATECHANGE = 'onreadystatechange',
     DOMCONTENTLOADED = 'DOMContentLoaded',
     SECRET = '__IE8__' + Math.random(),
-    Object = window.Object,
+    // Object = window.Object,
     defineProperty = Object.defineProperty ||
     // just in case ...
     function (object, property, descriptor) {
@@ -89,6 +89,12 @@
     var descriptor = getOwnPropertyDescriptor(
       protoSource || protoDest, property
     );
+
+    if (!descriptor) {
+      // console.warn("no fallback descriptor for ", protoDest, "#", property, " in ", protoSource);
+      return false;
+    }
+
     defineProperty(
       protoDest,
       'textContent',

--- a/src/ie8.js
+++ b/src/ie8.js
@@ -1,6 +1,6 @@
 
   /*! (C) WebReflection Mit Style License */
-  // if (document.createEvent) return;
+  if (document.createEvent) return;
   var
     DUNNOABOUTDOMLOADED = true,
     READYEVENTDISPATCHED = false,
@@ -89,12 +89,6 @@
     var descriptor = getOwnPropertyDescriptor(
       protoSource || protoDest, property
     );
-
-    if (!descriptor) {
-      // console.warn("no fallback descriptor for ", protoDest, "#", property, " in ", protoSource);
-      return false;
-    }
-
     defineProperty(
       protoDest,
       'textContent',


### PR DESCRIPTION
These tweaks ensure that `ie8.js` works in IE9:

1. Don't return early `if (document.createEvent)`, since IE9 implements this needs shimming elsewhere.
1. Don't alias `Object` locally, as this breaks in browserified builds (specifically, when running tests in [zuul](https://github.com/defunctzombie/zuul)).
1. Bail out of `commonTextDescriptor()` if the fallback descriptor doesn't exist, which fixes #14.

Preferably, shims would only be applied if the implementation was broken, but this would require a pretty significant refactor. IE9 gets a bunch of shims that it doesn't necessarily need, but because they work as expected we're good.