### PR TITLE
FIX: addEventListener should fail silently when executing an uncallable handler

### DIFF
--- a/src/ie8.js
+++ b/src/ie8.js
@@ -57,7 +57,7 @@
         typeof handler.handleEvent === 'function'
       ) {
         handler.handleEvent(evt);
-      } else {
+      } else if (typeof handler.call === 'function') {
         handler.call(currentTarget, evt);
       }
       if (evt.stoppedImmediatePropagation) break;


### PR DESCRIPTION
 ## Test Case

1. Add an event listener to a button with an uncallable handler `button.addEventListener('click', {})`
2. Cause that event to fire

## Actual Results

IE8: An error is thrown that can (in some cases) prevent execution of other scripts
NON-IE8: The handler fails silently

## Expected results

The handler should fail silently or throw an error and continue execution of handlers registered to the firing event.

## This solution

This solution causes the handler to fail silently like it does in modern browsers.