### PR TITLE
Added Makefile dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,12 @@
   "main": "./build/ie8.max.js",
   "devDendencies": {
     "wru": ">= 0.0.0"
+  },
+  "devDependencies": {
+    "jshint": "^2.9.1",
+    "markdown": "^0.5.0",
+    "polpetta": "^0.3.10",
+    "uglify-js": "^2.6.1",
+    "wru": "^0.2.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,14 +20,11 @@
     "url": "git://github.com/WebReflection/ie8.git"
   },
   "main": "./build/ie8.max.js",
-  "devDendencies": {
-    "wru": ">= 0.0.0"
-  },
   "devDependencies": {
     "jshint": "^2.9.1",
     "markdown": "^0.5.0",
     "polpetta": "^0.3.10",
-    "uglify-js": "^2.6.1",
+    "uglify-js": "^1.3.5",
     "wru": "^0.2.7"
   }
 }


### PR DESCRIPTION
If you add these npm dependencies to package json then developers will be able to

```
git clone [...]
npm install [...]
make
```

I noticed that you do have something for downloading npm dependencies in your Makefile, so feel free to close this if you don't agree.