### PR TITLE
Added support of style.opacity

### DIFF
--- a/src/ie8.js
+++ b/src/ie8.js
@@ -702,7 +702,8 @@
         ;
         if (!self[ontype]) {
           self[ontype] = function(e) {
-            return commonEventLoop(self, verify(self, e), handlers, false);
+            var retval = commonEventLoop(self, verify(self, e), handlers, false);
+            return retval !== true ? retval : undefined;
           };
         }
         handlers = self[ontype][SECRET] || (

--- a/src/ie8.js
+++ b/src/ie8.js
@@ -237,6 +237,32 @@
     }(getOwnPropertyDescriptor(window.CSSStyleSheet.prototype, 'cssText')))
   );
 
+  var opacityre = /\b\s*alpha\s*\(\s*opacity\s*=\s*(\d+)\s*\)/;
+  defineProperty(
+    window.CSSStyleDeclaration.prototype,
+    'opacity', {
+      get: function() {
+        var m = this.filter.match(opacityre);
+        return m ? (m[1] / 100).toString() : '';
+      },
+      set: function(value) {
+        this.zoom = 1;
+        var found = false;
+        if (value < 1) {
+          value = ' alpha(opacity=' + Math.round(value * 100) + ')';
+        }
+        else {
+          value = '';
+        }
+        this.filter = this.filter.replace(opacityre,
+                        function() { found = true; return value; });
+        if (!found && value) {
+          this.filter += value;
+        }
+      }
+    }
+  );
+
   defineProperties(
     ElementPrototype,
     {
@@ -631,6 +657,9 @@
             left,
             rtLeft
           ;
+          if (name == 'opacity') {
+            return style.opacity || '1';
+          }
           name = (name === 'float' ? 'style-float' : name).replace(re, place);
           result = currentStyle ? currentStyle[name] : style[name];
           if (notpixel.test(result) && !position.test(name)) {

--- a/src/ie8.js
+++ b/src/ie8.js
@@ -702,8 +702,7 @@
         ;
         if (!self[ontype]) {
           self[ontype] = function(e) {
-            var retval = commonEventLoop(self, verify(self, e), handlers, false);
-            return retval !== true ? retval : undefined;
+            return commonEventLoop(self, verify(self, e), handlers, false);
           };
         }
         handlers = self[ontype][SECRET] || (

--- a/test/ie8.js
+++ b/test/ie8.js
@@ -16,10 +16,11 @@ wru.createEvent = function(type, bubbles, cancelable) {
 };
 
 wru.test([{
-    name: 'getComputedStyle',
+    name: 'getComputedStyle and style.opacity',
     test: function () {
       var div = document.createElement('div');
       div.style.marginTop = '50%';
+      div.style.opacity = '0.75';
       document.body.insertBefore(
         div,
         document.body.firstChild
@@ -27,6 +28,7 @@ wru.test([{
       wru.assert('the amount is in pixels', /^\d+px$/.test(
         getComputedStyle(div, null).getPropertyValue('margin-top')
       ));
+      wru.assert(getComputedStyle(div, null).getPropertyValue('opacity') === '0.75');
       document.body.removeChild(div);
     }
   }, {


### PR DESCRIPTION
I think ie8.js is the right place for this to implement, since it already adds `getComputedStyle`.
With this patch it is possible to set the `opacity` property on each element.style.