### PR TITLE
Changed return value of window based event listeners

### DIFF
--- a/src/ie8.js
+++ b/src/ie8.js
@@ -702,7 +702,7 @@
         ;
         if (!self[ontype]) {
           self[ontype] = function(e) {
-            return commonEventLoop(self, verify(self, e), handlers, false);
+            return commonEventLoop(self, verify(self, e), handlers, false) && undefined;
           };
         }
         handlers = self[ontype][SECRET] || (


### PR DESCRIPTION
For "beforeunload" events the return value must be "undefined" instead of "true" to prevent the appearance of a dialog box.